### PR TITLE
Rely on AAD Object IDs instead of user principal names

### DIFF
--- a/brainy-bot/migrations/001.do.sql
+++ b/brainy-bot/migrations/001.do.sql
@@ -8,7 +8,7 @@ CREATE TABLE [dbo].[action]
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[typeid] [int] NOT NULL,
 	[taskid] [int] NOT NULL,
-	[userupn] [nvarchar](250) NOT NULL,
+	[useraadobjectid] [nvarchar](250) NOT NULL,
 	[comment] [nvarchar](1500) NULL,
 	[created] [datetime] NOT NULL,
 	CONSTRAINT [PK_action] PRIMARY KEY CLUSTERED 
@@ -40,9 +40,9 @@ GO
 CREATE TABLE [dbo].[assignment]
 (
 	[id] [int] IDENTITY(1,1) NOT NULL,
-	[userupn] [nvarchar](250) NOT NULL,
+	[useraadobjectid] [nvarchar](250) NOT NULL,
 	[taskid] [int] NOT NULL,
-	[managerupn] [nvarchar](250) NOT NULL,
+	[manageraadobjectid] [nvarchar](250) NOT NULL,
 	[actionid] [int] NOT NULL,
 	[created] [datetime] NOT NULL,
 	CONSTRAINT [PK_assignment] PRIMARY KEY CLUSTERED 
@@ -60,7 +60,7 @@ CREATE TABLE [dbo].[feedback]
 (
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[taskid] [int] NOT NULL,
-	[userupn] [nvarchar](250) NOT NULL,
+	[useraadobjectid] [nvarchar](250) NOT NULL,
 	[comment] [nvarchar](1500) NULL,
 	[rating] [int] NULL,
 	[created] [datetime] NOT NULL,
@@ -77,11 +77,11 @@ SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [dbo].[membership]
 (
-	[userupn] [nvarchar](250) NOT NULL,
+	[useraadobjectid] [nvarchar](250) NOT NULL,
 	[typeid] [int] NOT NULL,
 	CONSTRAINT [PK_membership] PRIMARY KEY CLUSTERED 
 (
-	[userupn] ASC,
+	[useraadobjectid] ASC,
 	[typeid] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
@@ -133,7 +133,7 @@ CREATE TABLE [dbo].[task]
 	[goal] [nvarchar](200) NOT NULL,
 	[requiredskills] [nvarchar](1000) NOT NULL,
 	[statusid] [int] NOT NULL,
-	[ownerupn] [nvarchar](250) NOT NULL,
+	[owneraadobjectid] [nvarchar](250) NOT NULL,
 	[created] [datetime] NOT NULL,
 	[conversationreference] [nvarchar](max) NULL,
 	CONSTRAINT [PK_engagement] PRIMARY KEY CLUSTERED 
@@ -164,17 +164,14 @@ SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [dbo].[user]
 (
-	[upn] [nvarchar](250) NOT NULL,
 	[aadobjectid] [nvarchar](500) NOT NULL,
 	[name] [nvarchar](500) NOT NULL,
 	[givenname] [nvarchar](500) NOT NULL,
-	[surname] [nvarchar](500) NOT NULL,
-	[emailaddress] [nvarchar](500) NOT NULL,
 	[conversationreference] [nvarchar](max) NOT NULL,
 	[availability] [bit] NOT NULL,
 	CONSTRAINT [PK_user_1] PRIMARY KEY CLUSTERED 
 (
-	[upn] ASC
+	[aadobjectid] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 GO

--- a/brainy-bot/src/controllers/bots/MainBot.ts
+++ b/brainy-bot/src/controllers/bots/MainBot.ts
@@ -95,14 +95,14 @@ export class MainBot extends TeamsActivityHandler {
     const userprofile = await SqlConnector.getUserprofileByUpn(
       member.userPrincipalName!
     );
+    if (!member.aadObjectId) {
+      return;
+    }
     if (!userprofile) {
       await SqlConnector.insertUser(
-        member.userPrincipalName!,
-        member.aadObjectId!,
+        member.aadObjectId,
         member.name,
-        member.givenName!,
-        member.surname!,
-        member.email!,
+        member.givenName || member.name,
         JSON.stringify(conversationReference)
       );
 

--- a/brainy-bot/src/controllers/bots/manager/cases/AssignspecialistCase.ts
+++ b/brainy-bot/src/controllers/bots/manager/cases/AssignspecialistCase.ts
@@ -6,13 +6,14 @@ import {enUS} from "../../../../resources/Resources";
 
 export class AssignspecialistCase {
   static async executeCase(formData: FormData, ctx: TurnContext) {
+    delete formData.specialistAadObjectId;
     delete formData.specialistUpn;
-    const specialists = await SqlConnector.getUpnAndNameOfAvailableSpecialists();
+    const specialists = await SqlConnector.getAadObjectIdAndNameOfAvailableSpecialists();
     const formattedSpecialists = [];
     for (const specialist of specialists) {
       formattedSpecialists.push({
         title: specialist.name,
-        value: specialist.upn,
+        value: specialist.aadobjectid,
       });
     }
     if (formattedSpecialists.length > 0) {

--- a/brainy-bot/src/controllers/bots/manager/cases/DeclineCase.ts
+++ b/brainy-bot/src/controllers/bots/manager/cases/DeclineCase.ts
@@ -31,7 +31,7 @@ export class DeclineCase {
     }
     await SqlConnector.insertAction(
       1,
-      userProfile.upn,
+      userProfile.aadobjectid,
       formData.taskId,
       formData.comment
     );
@@ -42,7 +42,7 @@ export class DeclineCase {
         formData.comment
       ),
     });
-    await sendActivitiesToUser(formData.taskOwnerUpn, [
+    await sendActivitiesToUser(formData.taskOwnerAadObjectId, [
       {
         attachments: [
           CardFactory.adaptiveCard(

--- a/brainy-bot/src/controllers/bots/privatemessage/cases/DeclineCase.ts
+++ b/brainy-bot/src/controllers/bots/privatemessage/cases/DeclineCase.ts
@@ -15,7 +15,7 @@ export class DeclineCase {
     if (
       !(await SharedValidators.taskIsPendingSpecialist(formData.taskId)) ||
       !(await SharedValidators.specialistIsCurrentlyAssignedToTask(
-        userProfile.upn,
+        userProfile.aadobjectid,
         formData.taskId
       ))
     ) {
@@ -43,7 +43,7 @@ export class DeclineCase {
     await SqlConnector.updateTaskStatusId(formData.taskId, 1);
     await SqlConnector.insertAction(
       1,
-      userProfile.upn,
+      userProfile.aadobjectid,
       formData.taskId,
       formData.comment
     );

--- a/brainy-bot/src/controllers/bots/privatemessage/cases/OptinCase.ts
+++ b/brainy-bot/src/controllers/bots/privatemessage/cases/OptinCase.ts
@@ -6,6 +6,9 @@ import {enUS} from "../../../../resources/Resources";
 export class OptinCase {
   static async executeCase(userProfile: User, ctx: TurnContext) {
     await ctx.sendActivity(enUS.optinNotification);
-    await SqlConnector.updateUserprofileAvailability(userProfile.upn, 1);
+    await SqlConnector.updateUserprofileAvailability(
+      userProfile.aadobjectid,
+      1
+    );
   }
 }

--- a/brainy-bot/src/controllers/bots/privatemessage/cases/OptoutCase.ts
+++ b/brainy-bot/src/controllers/bots/privatemessage/cases/OptoutCase.ts
@@ -8,6 +8,9 @@ export class OptoutCase {
     await ctx.sendActivity({
       attachments: [CardFactory.adaptiveCard(optoutCard())],
     });
-    await SqlConnector.updateUserprofileAvailability(userProfile.upn, 0);
+    await SqlConnector.updateUserprofileAvailability(
+      userProfile.aadobjectid,
+      0
+    );
   }
 }

--- a/brainy-bot/src/controllers/bots/privatemessage/cases/TaskfeedbacksubmitCase.ts
+++ b/brainy-bot/src/controllers/bots/privatemessage/cases/TaskfeedbacksubmitCase.ts
@@ -5,8 +5,13 @@ import {FormData} from "../../../../models/FormData";
 import {enUS} from "../../../../resources/Resources";
 
 export class TaskfeedbacksubmitCase {
-  private static async userIsTaskOwner(userUpn: string, taskId: number) {
-    if ((await SqlConnector.getTaskOwnerUpn(taskId)) === userUpn) {
+  private static async userIsTaskOwner(
+    userAadObjectId: string,
+    taskId: number
+  ) {
+    if (
+      (await SqlConnector.getTaskOwnerAadObjectId(taskId)) === userAadObjectId
+    ) {
       return true;
     }
     return false;
@@ -26,14 +31,14 @@ export class TaskfeedbacksubmitCase {
     ctx: TurnContext
   ) {
     if (
-      !(await this.userIsTaskOwner(userProfile.upn, formData.taskId)) ||
+      !(await this.userIsTaskOwner(userProfile.aadobjectid, formData.taskId)) ||
       !(await this.taskHasNoFeedback(formData.taskId))
     ) {
       throw Error(enUS.exceptions.information.feedbackSubmissionFailed);
     }
     await SqlConnector.insertFeedback(
       formData.taskId,
-      userProfile.upn,
+      userProfile.aadobjectid,
       formData.comment,
       formData.rating
     );

--- a/brainy-bot/src/controllers/bots/privatemessage/cases/TasksubmitCase.ts
+++ b/brainy-bot/src/controllers/bots/privatemessage/cases/TasksubmitCase.ts
@@ -21,7 +21,7 @@ export class TasksubmitCase {
       formData.taskUrl,
       formData.taskGoal,
       formData.taskRequiredSkills,
-      formData.taskOwnerUpn
+      formData.taskOwnerAadObjectId
     );
     const taskValues = Object.values(task);
     if (taskValues.includes("") || taskValues.includes(undefined)) {
@@ -35,6 +35,7 @@ export class TasksubmitCase {
   }
 
   static async executeCase(formData: FormData, ctx: TurnContext) {
+    formData = this.parseFormDataToAddTaskLength(formData);
     if (!this.taskIsValid(formData)) {
       trackDetailedException(
         new Error(enUS.exceptions.information.newTaskFormDataMissing),
@@ -69,7 +70,7 @@ export class TasksubmitCase {
       formData.taskUrl,
       formData.taskGoal,
       formData.taskRequiredSkills,
-      formData.taskOwnerUpn
+      formData.taskOwnerAadObjectId
     );
     const taskId = await SqlConnector.insertTask(task);
     formData["taskId"] = taskId;
@@ -86,5 +87,24 @@ export class TasksubmitCase {
     await ctx.sendActivity({
       attachments: [CardFactory.adaptiveCard(confirmTaskCard())],
     });
+  }
+
+  static parseFormDataToAddTaskLength(formData: FormData) {
+    const allowedLengthUnits = ["hour", "day", "week", "month"];
+    if (
+      formData["taskLengthValue"] > 0 &&
+      allowedLengthUnits.includes(formData["taskLengthUnit"])
+    ) {
+      if (formData["taskLengthValue"] > 1) {
+        formData[
+          "taskLength"
+        ] = `${formData.taskLengthValue} ${formData.taskLengthUnit}s`;
+      } else {
+        formData[
+          "taskLength"
+        ] = `${formData.taskLengthValue} ${formData.taskLengthUnit}`;
+      }
+    }
+    return formData;
   }
 }

--- a/brainy-bot/src/controllers/utils/SendActivities.ts
+++ b/brainy-bot/src/controllers/utils/SendActivities.ts
@@ -45,11 +45,11 @@ export async function sendActivitiesToManagerChannel(
   }
   const conversationReference = {
     conversation: {
-      conversationType: "channsssel",
+      conversationType: "channel",
       id: teamId,
       tenantId: currentTenantId,
       isGroup: true,
-      name: "newTask",
+      name: "newActivity",
     },
     channelId: "msteams",
     serviceUrl: currentServiceUrl,

--- a/brainy-bot/src/controllers/utils/SendActivities.ts
+++ b/brainy-bot/src/controllers/utils/SendActivities.ts
@@ -4,11 +4,11 @@ import {adapter} from "../../app";
 import {enUS} from "../../resources/Resources";
 
 export async function sendActivitiesToUser(
-  upn: string,
+  aadObjectId: string,
   activities: Array<Partial<Activity>>
 ): Promise<void> {
-  const conversationReference = await SqlConnector.getConversationReferenceByUpn(
-    upn
+  const conversationReference = await SqlConnector.getConversationReferenceByAadObjectId(
+    aadObjectId
   );
   if (!conversationReference) {
     throw Error(enUS.exceptions.error.userNotFound);

--- a/brainy-bot/src/controllers/utils/SharedValidators.ts
+++ b/brainy-bot/src/controllers/utils/SharedValidators.ts
@@ -2,12 +2,12 @@ import {SqlConnector} from "../../connectors/SqlConnector";
 
 export class SharedValidators {
   static async specialistIsCurrentlyAssignedToTask(
-    specialistUpn: string,
+    specialistAadObjectId: string,
     taskId: number
   ) {
     if (
-      (await SqlConnector.getLastAssignedSpecialistUpn(taskId)) ===
-      specialistUpn
+      (await SqlConnector.getLastAssignedSpecialistAadObjectId(taskId)) ===
+      specialistAadObjectId
     ) {
       return true;
     }

--- a/brainy-bot/src/models/Database.ts
+++ b/brainy-bot/src/models/Database.ts
@@ -8,7 +8,7 @@ export interface Task {
   goal: string;
   requiredskills: string;
   statusid: number;
-  ownerupn: string;
+  owneraadobjectid: string;
   created: string;
   conversationreference: string;
 }
@@ -17,16 +17,16 @@ export interface Action {
   id: number;
   typeid: number;
   taskid: number;
-  userupn: string;
+  useraadobjectid: string;
   comment: string;
   created: string;
 }
 
 export interface Assignment {
   id: number;
-  userupn: string;
+  useraadobjectid: string;
   taskid: number;
-  managerupn: string;
+  manageraadobjectid: string;
   created: string;
   actionid: number;
 }
@@ -34,7 +34,7 @@ export interface Assignment {
 export interface Feedback {
   id: number;
   taskid: number;
-  userupn: string;
+  useraadobjectid: string;
   comment: string;
   rating: number;
   created: string;
@@ -46,17 +46,14 @@ export interface ManagerTeam {
 }
 
 export interface Membership {
-  userupn: string;
+  useraadobjectid: string;
   typeid: number;
 }
 
 export interface User {
-  upn: string;
   aadobjectid: string;
   name: string;
   givenname: string;
-  surname: string;
-  emailaddress: string;
   conversationreference: string;
   availability: boolean;
 }

--- a/brainy-bot/src/models/FormData.ts
+++ b/brainy-bot/src/models/FormData.ts
@@ -9,11 +9,16 @@ export interface FormData {
   taskUrl: string;
   taskGoal: string;
   taskRequiredSkills: string;
+  taskOwnerAadObjectId: string;
   taskOwnerUpn: string;
   taskOwnerName: string;
   taskOwnerGivenName: string;
   comment: string;
   rating: number;
+  managerAadObjectId: string;
   managerUpn: string;
+  specialistAadObjectId: string;
+  specialistName: string;
+  specialistGivenName: string;
   specialistUpn: string;
 }

--- a/brainy-bot/src/models/FormTask.ts
+++ b/brainy-bot/src/models/FormTask.ts
@@ -7,7 +7,7 @@ export class FormTask {
     url: string,
     goal: string,
     requiredSkills: string,
-    ownerUpn: string
+    ownerAadObjectId: string
   ) {
     this.customer = customer;
     this.length = length;
@@ -16,7 +16,7 @@ export class FormTask {
     this.url = url;
     this.goal = goal;
     this.requiredSkills = requiredSkills;
-    this.ownerUpn = ownerUpn;
+    this.ownerAadObjectId = ownerAadObjectId;
   }
   customer: string;
   length: string;
@@ -25,5 +25,5 @@ export class FormTask {
   url: string;
   goal: string;
   requiredSkills: string;
-  ownerUpn: string;
+  ownerAadObjectId: string;
 }

--- a/brainy-bot/src/views/adaptivecards/manager/chooseSpecialistCard.ts
+++ b/brainy-bot/src/views/adaptivecards/manager/chooseSpecialistCard.ts
@@ -8,7 +8,7 @@ export const chooseSpecialistCard = (
     taskLength: string;
     taskName: string;
     taskType: string;
-    taskOwnerUpn: string;
+    taskOwnerAadObjectId: string;
     taskUrl: string;
     taskGoal: string;
     taskRequiredSkills: string;
@@ -33,7 +33,7 @@ export const chooseSpecialistCard = (
               },
               {
                 type: "Input.ChoiceSet",
-                id: "specialistUpn",
+                id: "specialistAadObjectId",
                 style: "compact",
                 isMultiSelect: false,
                 choices: availableSpecialists,

--- a/brainy-bot/src/views/adaptivecards/manager/qualifyTaskCard.ts
+++ b/brainy-bot/src/views/adaptivecards/manager/qualifyTaskCard.ts
@@ -7,6 +7,7 @@ export const qualifyTaskCard = (opt: {
   taskLength: string;
   taskName: string;
   taskType: string;
+  taskOwnerAadObjectId: string;
   taskOwnerUpn: string;
   taskUrl: string;
   taskGoal: string;

--- a/brainy-bot/src/views/adaptivecards/privatemessage/addTaskCard.ts
+++ b/brainy-bot/src/views/adaptivecards/privatemessage/addTaskCard.ts
@@ -122,6 +122,7 @@ export const addTaskCard = (
                           enUS.adaptiveCards.addTaskCard
                             .taskLengthValueNumberInputPlaceholder,
                         value: opt.taskLengthValue,
+                        max: 100000,
                       },
                     ],
                   },

--- a/brainy-bot/src/views/adaptivecards/privatemessage/newTaskCard.ts
+++ b/brainy-bot/src/views/adaptivecards/privatemessage/newTaskCard.ts
@@ -7,7 +7,9 @@ export const newTaskCard = (
     taskLength: string;
     taskName: string;
     taskType: string;
+    taskOwnerAadObjectId: string;
     taskOwnerUpn: string;
+    managerAadObjectId: string;
     managerUpn: string;
     taskUrl: string;
     taskGoal: string;

--- a/brainy-bot/src/views/adaptivecards/privatemessage/specialistFoundTaskownerCard.ts
+++ b/brainy-bot/src/views/adaptivecards/privatemessage/specialistFoundTaskownerCard.ts
@@ -5,6 +5,7 @@ export const specialistFoundTaskownerCard = (opt: {
   taskName: string;
   specialistName: string;
   specialistGivenName: string;
+  specialistAadObjectId: string;
   specialistUpn: string;
   taskUrl: string;
 }) => {
@@ -17,7 +18,6 @@ export const specialistFoundTaskownerCard = (opt: {
   const meetingLink =
     enUS.adaptiveCards.meetingLinkWihoutAttendees(opt.taskCustomer) +
     `&attendees=${opt.specialistUpn}`;
-
   const cardData = {
     type: "AdaptiveCard",
     body: [

--- a/brainy-configuration/app.js
+++ b/brainy-configuration/app.js
@@ -151,9 +151,11 @@ app.get("/", (req, res) => {
   res.sendFile("index.html", options);
 });
 
-app.get("/api/users/upn", async (req, res) => {
+app.get("/api/users", async (req, res) => {
   try {
-    result = await executeSimpleQuery("SELECT [upn] FROM [dbo].[user]");
+    result = await executeSimpleQuery(
+      "SELECT [aadobjectid],[name] FROM [dbo].[user]"
+    );
     res.send(result);
   } catch {
     res.sendStatus(503);
@@ -174,9 +176,9 @@ app.post("/api/memberships", async (req, res) => {
     const pool = new sql.ConnectionPool(sqlConnectionConfig);
     await pool.connect();
     const queryDefinition =
-      "INSERT INTO [dbo].[membership] ([userupn],[typeid]) VALUES (@userupn,@typeid)";
+      "INSERT INTO [dbo].[membership] ([useraadobjectid],[typeid]) VALUES (@useraadobjectid,@typeid)";
     const request = new sql.Request(pool);
-    request.input("userupn", sql.NVarChar, req.body.userUpn);
+    request.input("useraadobjectid", sql.NVarChar, req.body.userAadObjectId);
     request.input("typeid", sql.NVarChar, req.body.typeId);
     await request.query(queryDefinition);
     await pool.close();
@@ -186,14 +188,14 @@ app.post("/api/memberships", async (req, res) => {
   }
 });
 
-app.delete("/api/memberships/:userUpn/:typeId", async (req, res) => {
+app.delete("/api/memberships/:userAadObjectId/:typeId", async (req, res) => {
   try {
     const pool = new sql.ConnectionPool(sqlConnectionConfig);
     await pool.connect();
     const queryDefinition =
-      "DELETE [dbo].[membership] WHERE userupn = @userupn AND typeid = @typeid";
+      "DELETE [dbo].[membership] WHERE useraadobjectid = @useraadobjectid AND typeid = @typeid";
     const request = new sql.Request(pool);
-    request.input("userupn", sql.NVarChar, req.params.userUpn);
+    request.input("userAadObjectId", sql.NVarChar, req.params.userAadObjectId);
     request.input("typeid", sql.Int, req.params.typeId);
     await request.query(queryDefinition);
     await pool.close();

--- a/brainy-configuration/package.json
+++ b/brainy-configuration/package.json
@@ -38,6 +38,7 @@
     "@angular/cli": "^8.3.21",
     "@angular/compiler-cli": "~8.2.11",
     "codelyzer": "^5.2.1",
+    "prettier": "^2.0.5",
     "tslint": "~5.15.0",
     "typescript": "~3.5.3"
   }

--- a/brainy-configuration/src/app/app.component.css
+++ b/brainy-configuration/src/app/app.component.css
@@ -22,12 +22,12 @@
 
 .form-control:focus {
   box-shadow: 0 0 0 0.05rem #7e62ac !important;
-  border-color: #A88ED5;
+  border-color: #a88ed5;
 }
 
 .form-small {
   width: 30%;
-  margin: 0 auto; 
+  margin: 0 auto;
   margin-bottom: 15px;
 }
 
@@ -83,25 +83,24 @@ table {
 
 .btn-primary,
 .btn-primary:hover,
-.btn-primary:visited
-{
+.btn-primary:visited {
   margin: 25px;
   background-color: #7e62ac !important;
   border-color: #7e62ac !important;
 }
 .btn-primary:active {
   background-color: #7e62ac !important;
-  border-color: #7e62ac  !important;
+  border-color: #7e62ac !important;
 }
 .btn-outline-primary {
-  background-color: #7e62ac  !important;
+  background-color: #7e62ac !important;
   border-color: #7e62ac !important;
-  color: white
+  color: white;
 }
-.btn:focus { 
-  box-shadow: none
+.btn:focus {
+  box-shadow: none;
 }
 
 .btn:hover {
-  opacity: 0.7
+  opacity: 0.7;
 }

--- a/brainy-configuration/src/app/app.component.html
+++ b/brainy-configuration/src/app/app.component.html
@@ -1,7 +1,6 @@
 <div *ngIf="pageLoaded">
-
   <div class="toolbar" role="banner">
-    <span class=toolbar-title>Welcome to Brainy's Configuration</span>
+    <span class="toolbar-title">Welcome to Brainy's Configuration</span>
     <span class="toolbar-user"><span class="d-none d-lg-inline">{{ loggedInUser.upn }}</span><a class="btn-logout"
         href="/logout">Log Out</a></span>
   </div>
@@ -10,9 +9,10 @@
   <form class="form-small" #managerTeamForm="ngForm" (ngSubmit)="submitManagerTeamId(managerTeamForm.form)">
     <label class="form-label" for="teamid">Manager Team ID</label>
     <div class="input-group">
-      <input required class=" form-control form-control-sm" type="text" [(ngModel)]="managerTeam.teamid" name="teamid"
+      <input required class="form-control form-control-sm" type="text" [(ngModel)]="managerTeam.teamid" name="teamid"
         #teamid="ngModel" required />
       <div class="input-group-append">
+
         <button class="btn btn-outline-primary btn-sm" type="submit" [disabled]="!teamid.valid">
           Submit
         </button>
@@ -23,38 +23,42 @@
   <h2 class="text-middle">Configure User Memberships</h2>
   <form class="form-big">
     <input class="form-control form-control-sm" type="text" placeholder="Search" name="searchString"
-      [(ngModel)]="searchString">
+      [(ngModel)]="searchString" />
   </form>
 
   <table class="table table-sm table-striped">
     <thead>
       <tr>
-        <th>User UPN</th>
+        <th>User Name</th>
+        <th>AAD Object ID</th>
         <th>Manager</th>
         <th>Task executor</th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let userMembership of userMemberships | filter : 'userupn' : searchString;">
+      <tr *ngFor="
+          let userMembership of userMemberships | filter: 'name':searchString">
         <td>
-          {{userMembership.userupn}}
+          {{ userMembership.name }}
+        </td>
+        <td>
+          {{ userMembership.aadobjectid }}
         </td>
         <td>
           <button *ngIf="userMembership.manager === false" class="btn"
-            (click)="insertMembership(userMembership.userupn, 'manager')">❌</button>
+            (click)="insertMembership(userMembership.aadobjectid, 'manager', userMembership.name)">❌</button>
           <button *ngIf="userMembership.manager === true" class="btn"
-            (click)="deleteMembership(userMembership.userupn, 'manager')">✔️</button>
+            (click)="deleteMembership(userMembership.aadobjectid, 'manager', userMembership.name)">✔️</button>
         </td>
         <td>
-          <button *ngIf="userMembership.specialist === false" class=" btn"
-            (click)="insertMembership(userMembership.userupn, 'specialist')">❌</button>
+          <button *ngIf="userMembership.specialist === false" class="btn"
+            (click)="insertMembership(userMembership.aadobjectid,'specialist',userMembership.name)">❌</button>
           <button *ngIf="userMembership.specialist === true" class="btn"
-            (click)="deleteMembership(userMembership.userupn, 'specialist')">✔️</button>
+            (click)="deleteMembership( userMembership.aadobjectid,'specialist',userMembership.name)">✔️</button>
         </td>
       </tr>
     </tbody>
   </table>
-
 </div>
 
 <div *ngIf="!pageLoaded">

--- a/brainy-configuration/src/app/app.component.ts
+++ b/brainy-configuration/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { ManagerTeam } from "./../models/ManagerTeam";
 import { AppService } from "./app.service";
 import { Component, OnInit } from "@angular/core";
 import { ToastrService } from "ngx-toastr";
-import { User } from "src/models/User";
+import { LoggedInUser } from "src/models/LoggedInUser";
 
 @Component({
   selector: "app-root",
@@ -14,7 +14,7 @@ export class AppComponent implements OnInit {
   pageLoaded = false;
   title = "brainy-configuration";
   managerTeam: ManagerTeam;
-  loggedInUser: User;
+  loggedInUser: LoggedInUser;
   userMemberships: UserMembership[];
   searchString: string;
 
@@ -39,40 +39,42 @@ export class AppComponent implements OnInit {
       this.toastr.error("The entered Team ID deeplink is invalid", "Whoopsie!");
     }
   }
-  async insertMembership(userUpn: string, membershipType: string) {
+  async insertMembership(
+    aadObjectId: string,
+    membershipType: string,
+    name: string
+  ) {
     try {
       if (membershipType === "manager") {
-        await this.appService.insertMembership(userUpn, 1);
+        await this.appService.insertMembership(aadObjectId, 1);
       } else if (membershipType === "specialist") {
-        await this.appService.insertMembership(userUpn, 2);
+        await this.appService.insertMembership(aadObjectId, 2);
       }
       this.userMemberships.find(
-        (userMembership) => userMembership.userupn === userUpn
+        (userMembership) => userMembership.aadobjectid === aadObjectId
       )[membershipType] = true;
-      this.toastr.success(`Assigned membership to ${userUpn}`, "Success!");
+      this.toastr.success(`Assigned membership to ${name}`, "Success!");
     } catch {
-      this.toastr.error(
-        `Couldn't assign membership to ${userUpn}`,
-        "Whoopsie!"
-      );
+      this.toastr.error(`Couldn't assign membership to ${name}`, "Whoopsie!");
     }
   }
-  async deleteMembership(userUpn: string, membershipType: string) {
+  async deleteMembership(
+    userAadObjectId: string,
+    membershipType: string,
+    name: string
+  ) {
     try {
       if (membershipType === "manager") {
-        await this.appService.deleteMembership(userUpn, 1);
+        await this.appService.deleteMembership(userAadObjectId, 1);
       } else if (membershipType === "specialist") {
-        await this.appService.deleteMembership(userUpn, 2);
+        await this.appService.deleteMembership(userAadObjectId, 2);
       }
       this.userMemberships.find(
-        (userMembership) => userMembership.userupn === userUpn
+        (userMembership) => userMembership.aadobjectid === userAadObjectId
       )[membershipType] = false;
-      this.toastr.success(`Removed membership from ${userUpn}`, "Success!");
+      this.toastr.success(`Removed membership from ${name}`, "Success!");
     } catch {
-      this.toastr.error(
-        `Couldn't remove membership from ${userUpn}`,
-        "Whoopsie!"
-      );
+      this.toastr.error(`Couldn't remove membership from ${name}`, "Whoopsie!");
     }
   }
 

--- a/brainy-configuration/src/app/app.module.ts
+++ b/brainy-configuration/src/app/app.module.ts
@@ -14,7 +14,7 @@ import { ToastrModule } from "ngx-toastr";
     BrowserAnimationsModule,
     FormsModule,
     HttpClientModule,
-    ToastrModule.forRoot()
+    ToastrModule.forRoot(),
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/brainy-configuration/src/app/app.service.ts
+++ b/brainy-configuration/src/app/app.service.ts
@@ -22,8 +22,6 @@ export class AppService {
       .get<Membership[]>("/api/memberships")
       .toPromise();
     const users = await this.http.get<User[]>("/api/users").toPromise();
-    const userAadObjectIds: string[] = [];
-
     const userMemberships: UserMembership[] = [];
     users.forEach((user) => {
       userMemberships.push({
@@ -41,8 +39,6 @@ export class AppService {
         ),
       });
     });
-    console.log(userMemberships);
-
     return userMemberships;
   }
   async postManagerTeamId(teamId: string) {

--- a/brainy-configuration/src/app/search.pipe.ts
+++ b/brainy-configuration/src/app/search.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform, Injectable } from "@angular/core";
 
 @Pipe({
-  name: "filter"
+  name: "filter",
 })
 @Injectable()
 export class SearchPipe implements PipeTransform {
@@ -12,8 +12,8 @@ export class SearchPipe implements PipeTransform {
     if (!field || !value) {
       return items;
     }
-    return items.filter(item =>
-        item[field].toLowerCase().includes(value.toLowerCase())
+    return items.filter((item) =>
+      item[field].toLowerCase().includes(value.toLowerCase())
     );
   }
 }

--- a/brainy-configuration/src/models/LoggedInUser.ts
+++ b/brainy-configuration/src/models/LoggedInUser.ts
@@ -1,0 +1,3 @@
+export interface LoggedInUser {
+  upn: string;
+}

--- a/brainy-configuration/src/models/Membership.ts
+++ b/brainy-configuration/src/models/Membership.ts
@@ -1,4 +1,4 @@
 export interface Membership {
-  userupn: string;
+  useraadobjectid: string;
   typeid: number;
 }

--- a/brainy-configuration/src/models/User.ts
+++ b/brainy-configuration/src/models/User.ts
@@ -1,3 +1,4 @@
 export interface User {
-  upn: string;
+  aadobjectid: string;
+  name: string;
 }

--- a/brainy-configuration/src/models/UserMembership.ts
+++ b/brainy-configuration/src/models/UserMembership.ts
@@ -1,5 +1,6 @@
 export interface UserMembership {
-  userupn: string;
+  aadobjectid: string;
+  name: string;
   manager: boolean;
   specialist: boolean;
 }

--- a/brainy-configuration/yarn.lock
+++ b/brainy-configuration/yarn.lock
@@ -1233,11 +1233,6 @@ JSONStream@^1.3.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -1397,18 +1392,10 @@ app-root-path@^2.2.1:
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.2.1.tgz#d0df4a682ee408273583d43f6f79e9892624bc9a"
   integrity sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2245,11 +2232,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -2518,7 +2500,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2551,11 +2533,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-gateway@^4.2.0:
   version "4.2.0"
@@ -2612,11 +2589,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -2644,11 +2616,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -3317,20 +3284,6 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
@@ -3499,11 +3452,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -3692,7 +3640,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3796,7 +3744,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.5, ini@~1.3.0:
+ini@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -4792,15 +4740,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -4866,34 +4805,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.52, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.4.0:
   version "2.5.0"
@@ -4964,7 +4879,7 @@ npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6:
+npm-packlist@^1.1.12:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -5010,16 +4925,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -5181,7 +5086,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.4, osenv@^0.1.5:
+osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5595,6 +5500,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -5783,16 +5693,6 @@ raw-loader@3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -5821,7 +5721,7 @@ read-package-tree@5.3.1:
     readdir-scoped-modules "^1.0.0"
     util-promisify "^2.1.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -6059,7 +5959,7 @@ rimraf@3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -6157,7 +6057,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -6267,7 +6167,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -6650,7 +6550,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -6757,11 +6657,6 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
@@ -6820,7 +6715,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -7421,13 +7316,6 @@ which@^1.2.9, which@^1.3.1:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
These changes facilitate using AAD Object IDs for users instead of relying on user principal names. This refactor is essential as UPNs can be modified by tenant admins.